### PR TITLE
Fix TypeError when accessing undefined message content in SessionItem

### DIFF
--- a/src/client/components/SessionItem.tsx
+++ b/src/client/components/SessionItem.tsx
@@ -484,7 +484,7 @@ export const SessionItem: React.FC<SessionItemProps> = ({
                   <div className="match-role">{match.message.role}</div>
                   <div className="match-content">
                     {highlightText(
-                      match.highlights[0] || match.message.content.substring(0, 200),
+                      match.highlights[0] || extractMessageContent(match.message).substring(0, 200),
                       searchTerms,
                     )}
                   </div>
@@ -551,9 +551,12 @@ export const SessionItem: React.FC<SessionItemProps> = ({
                     whiteSpace: 'pre-wrap',
                   }}
                 >
-                  {message.content.length > 800
-                    ? message.content.substring(0, 800) + '...'
-                    : message.content}
+                  {(() => {
+                    const content = extractMessageContent(message);
+                    return content.length > 800
+                      ? content.substring(0, 800) + '...'
+                      : content;
+                  })()}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes a critical TypeError that occurred when clicking on session items with malformed or missing message content.

## 📋 Problem

The application crashed with the following error:
```
TypeError: Cannot read properties of undefined (reading 'length')
    at SessionItem.tsx:552:36
```

This happened when:
- Clicking the expand button (SVG icon) on session items
- Messages had undefined or missing `content` properties
- The code tried to access `message.content.length` directly without null checking

## ✅ Solution

- Replaced direct `message.content` access with the safe `extractMessageContent()` helper function
- Applied the fix in two locations:
  - Line 487: Search result highlights display
  - Lines 554-559: Expanded conversation view

The `extractMessageContent()` helper:
- Safely handles null/undefined messages
- Checks multiple content locations (`content`, `text`, `summary`, `message.content`)
- Supports both string and array content formats
- Returns empty string as fallback

## 🧪 Testing

- ✅ Build passes: `npm run build`
- ✅ No TypeScript errors
- ✅ Session items expand without crashes
- ✅ Messages with various content formats display correctly
- ✅ Search results render properly

## 📝 Changes

- `src/client/components/SessionItem.tsx`: Use safe content extraction instead of direct property access
