### PR TITLE
style: apply Prettier formatting to changes from PR #4

### DIFF
--- a/src/client/components/SessionItem.tsx
+++ b/src/client/components/SessionItem.tsx
@@ -552,10 +552,8 @@ export const SessionItem: React.FC<SessionItemProps> = ({
                   }}
                 >
                   {(() => {
-                    const content = extractMessageContent(message);
-                    return content.length > 800
-                      ? content.substring(0, 800) + '...'
-                      : content;
+                    const content = extractMessageContent(message)
+                    return content.length > 800 ? content.substring(0, 800) + '...' : content
                   })()}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Applied missing Prettier formatting to the undefined message content fix introduced in PR #4.

## Changes
- Format `src/client/components/SessionItem.tsx`
  - Remove semicolons (Prettier config: `semi: false`)
  - Convert ternary operator to single line

## Context
PR #4 (https://github.com/suthio/ccsearch/pull/4) added handling for undefined message content, but I forgot to apply Prettier formatting to those changes. This was caught by the recently added Prettier format check in CI.

## Verification
- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes

My apologies for missing the formatting. Will ensure to run format checks before committing in the future.